### PR TITLE
Reactoring exercise logic, added LP data

### DIFF
--- a/.openzeppelin/unknown-11155420.json
+++ b/.openzeppelin/unknown-11155420.json
@@ -155,6 +155,11 @@
       "address": "0xdA07acf472c6AfDAd3cf4d2cbb97Cc311f081c26",
       "txHash": "0xe1f954ab1dee49efdbcb632a1e752a18b69471505679632c0c9a19848274b34e",
       "kind": "transparent"
+    },
+    {
+      "address": "0xd61FA46d4e3CD47584a56fC20856Fdd197135756",
+      "txHash": "0x475871cc7112f3db3186cff7bdb9438574f8094d03688ed1aeedf45ad2134380",
+      "kind": "transparent"
     }
   ],
   "impls": {
@@ -21137,6 +21142,119 @@
           },
           "t_contract(ISportsAMMV2RiskManager)15916": {
             "label": "contract ISportsAMMV2RiskManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "3ec9a49e6af39d4c1916a7513304a5b8cac1b44a86f997e92b54091440189a84": {
+      "address": "0xa49A562E226cb47ae7422837E06390e7C6b9Ae17",
+      "txHash": "0x116769a9e6f42b48fd425b728ebd894d6ac0ccb88ba52e9b0ca15eec003281e4",
+      "layout": {
+        "solcVersion": "0.8.20",
+        "storage": [
+          {
+            "label": "owner",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "ProxyOwned",
+            "src": "contracts\\utils\\proxy\\ProxyOwned.sol:6"
+          },
+          {
+            "label": "nominatedOwner",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "ProxyOwned",
+            "src": "contracts\\utils\\proxy\\ProxyOwned.sol:7"
+          },
+          {
+            "label": "_initialized",
+            "offset": 20,
+            "slot": "1",
+            "type": "t_bool",
+            "contract": "ProxyOwned",
+            "src": "contracts\\utils\\proxy\\ProxyOwned.sol:8"
+          },
+          {
+            "label": "_transferredAtInit",
+            "offset": 21,
+            "slot": "1",
+            "type": "t_bool",
+            "contract": "ProxyOwned",
+            "src": "contracts\\utils\\proxy\\ProxyOwned.sol:9"
+          },
+          {
+            "label": "lastPauseTime",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_uint256",
+            "contract": "ProxyPausable",
+            "src": "contracts\\utils\\proxy\\ProxyPausable.sol:9"
+          },
+          {
+            "label": "paused",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_bool",
+            "contract": "ProxyPausable",
+            "src": "contracts\\utils\\proxy\\ProxyPausable.sol:10"
+          }
+        ],
+        "types": {
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)371_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_address": {
+            "label": "address",
             "numberOfBytes": "20"
           },
           "t_uint256": {

--- a/contracts/Overtime/LiquidityPool/SportsAMMV2LiquidityPoolData.sol
+++ b/contracts/Overtime/LiquidityPool/SportsAMMV2LiquidityPoolData.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import "../../utils/proxy/ProxyOwned.sol";
+import "../../utils/proxy/ProxyPausable.sol";
+import "./SportsAMMV2LiquidityPool.sol";
+
+contract SportsAMMV2LiquidityPoolData is Initializable, ProxyOwned, ProxyPausable {
+    struct LiquidityPoolData {
+        address collateral;
+        bool started;
+        uint maxAllowedDeposit;
+        uint round;
+        uint totalDeposited;
+        uint minDepositAmount;
+        uint maxAllowedUsers;
+        uint usersCurrentlyInPool;
+        bool canCloseCurrentRound;
+        bool paused;
+        uint roundLength;
+        uint allocationCurrentRound;
+        uint lifetimePnl;
+        uint roundEndTime;
+    }
+
+    struct UserLiquidityPoolData {
+        uint balanceCurrentRound;
+        uint balanceNextRound;
+        bool withdrawalRequested;
+        uint withdrawalShare;
+    }
+
+    function initialize(address _owner) external initializer {
+        setOwner(_owner);
+    }
+
+    /// @notice getLiquidityPoolData returns liquidity pool data
+    /// @param liquidityPool SportsAMMV2LiquidityPool
+    /// @return LiquidityPoolData
+    function getLiquidityPoolData(SportsAMMV2LiquidityPool liquidityPool) external view returns (LiquidityPoolData memory) {
+        uint round = liquidityPool.round();
+
+        return
+            LiquidityPoolData(
+                address(liquidityPool.collateral()),
+                liquidityPool.started(),
+                liquidityPool.maxAllowedDeposit(),
+                round,
+                liquidityPool.totalDeposited(),
+                liquidityPool.minDepositAmount(),
+                liquidityPool.maxAllowedUsers(),
+                liquidityPool.usersCurrentlyInPool(),
+                liquidityPool.canCloseCurrentRound(),
+                liquidityPool.paused(),
+                liquidityPool.roundLength(),
+                liquidityPool.allocationPerRound(round),
+                liquidityPool.cumulativeProfitAndLoss(round > 0 ? round - 1 : 0),
+                liquidityPool.getRoundEndTime(round)
+            );
+    }
+
+    /// @notice getUserLiquidityPoolData returns user liquidity pool data
+    /// @param liquidityPool SportsAMMV2LiquidityPool
+    /// @param user address of the user
+    /// @return UserLiquidityPoolData
+    function getUserLiquidityPoolData(
+        SportsAMMV2LiquidityPool liquidityPool,
+        address user
+    ) external view returns (UserLiquidityPoolData memory) {
+        uint round = liquidityPool.round();
+
+        return
+            UserLiquidityPoolData(
+                liquidityPool.balancesPerRound(round, user),
+                liquidityPool.balancesPerRound(round + 1, user),
+                liquidityPool.withdrawalRequested(user),
+                liquidityPool.withdrawalShare(user)
+            );
+    }
+}

--- a/contracts/Overtime/SportsAMMV2.sol
+++ b/contracts/Overtime/SportsAMMV2.sol
@@ -542,7 +542,6 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
                 totalQuote,
                 address(this),
                 _tradeDataInternal._differentRecipient,
-                msg.sender,
                 _tradeDataInternal._collateral == address(0) ? defaultCollateral : IERC20(_tradeDataInternal._collateral),
                 (block.timestamp + riskManager.expiryDuration())
             )

--- a/contracts/Overtime/SportsAMMV2.sol
+++ b/contracts/Overtime/SportsAMMV2.sol
@@ -389,17 +389,15 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
     /// @param _hasUserWon is winning ticket
     /// @param _cancelled is ticket cancelled (needed for referral and safe box fee)
     /// @param _buyInAmount ticket buy-in amount (needed for referral and safe box fee)
-    /// @param _ticketCreator ticket creator (needed for referral and safe box fee)
     function resolveTicket(
         address _ticketOwner,
         bool _hasUserWon,
         bool _cancelled,
         uint _buyInAmount,
-        address _ticketCreator,
         address _collateral
     ) external notPaused onlyKnownTickets(msg.sender) {
         if (!_cancelled) {
-            _handleReferrerAndSB(_buyInAmount, _ticketCreator, IERC20(_collateral));
+            _handleReferrerAndSB(_buyInAmount, _ticketOwner, IERC20(_collateral));
         }
         knownTickets.remove(msg.sender);
         if (activeTicketsPerUser[_ticketOwner].contains(msg.sender)) {

--- a/contracts/Overtime/SportsAMMV2.sol
+++ b/contracts/Overtime/SportsAMMV2.sol
@@ -739,12 +739,12 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
         if (!ticket.cancelled()) {
             _handleFees(ticket.buyInAmount(), ticketOwner, ticketCollateral);
         }
-        knownTickets.remove(msg.sender);
-        if (activeTicketsPerUser[ticketOwner].contains(msg.sender)) {
-            activeTicketsPerUser[ticketOwner].remove(msg.sender);
+        knownTickets.remove(_ticket);
+        if (activeTicketsPerUser[ticketOwner].contains(_ticket)) {
+            activeTicketsPerUser[ticketOwner].remove(_ticket);
         }
-        resolvedTicketsPerUser[ticketOwner].add(msg.sender);
-        emit TicketResolved(msg.sender, ticketOwner, ticket.isUserTheWinner());
+        resolvedTicketsPerUser[ticketOwner].add(_ticket);
+        emit TicketResolved(_ticket, ticketOwner, ticket.isUserTheWinner());
 
         uint amount = ticketCollateral.balanceOf(address(this));
         if (amount > 0) {

--- a/contracts/Overtime/SportsAMMV2.sol
+++ b/contracts/Overtime/SportsAMMV2.sol
@@ -423,7 +423,7 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
     function expireTickets(address[] calldata _tickets) external onlyOwner {
         for (uint i = 0; i < _tickets.length; i++) {
             if (Ticket(_tickets[i]).phase() == Ticket.Phase.Expiry) {
-                Ticket(_tickets[i]).expire(payable(safeBox));
+                Ticket(_tickets[i]).expire(payable(msg.sender));
             }
         }
     }

--- a/contracts/Overtime/SportsAMMV2.sol
+++ b/contracts/Overtime/SportsAMMV2.sol
@@ -677,7 +677,7 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
             uint referrerFeeByTier = referrals.getReferrerFee(referrer);
             if (referrerFeeByTier > 0) {
                 referrerShare = (_buyInAmount * referrerFeeByTier) / ONE;
-                if (referrerShare > ammBalance) {
+                if (ammBalance >= referrerShare) {
                     _collateral.safeTransfer(referrer, referrerShare);
                     emit ReferrerPaid(referrer, _tickerOwner, referrerShare, _buyInAmount);
                 }
@@ -687,7 +687,7 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
         if (fees > referrerShare) {
             uint safeBoxAmount = fees - referrerShare;
             ammBalance = _collateral.balanceOf(address(this));
-            if (safeBoxAmount > ammBalance) {
+            if (ammBalance >= safeBoxAmount) {
                 _collateral.safeTransfer(safeBox, safeBoxAmount);
                 emit SafeBoxFeePaid(safeBoxFee, safeBoxAmount);
             }

--- a/contracts/Overtime/SportsAMMV2Data.sol
+++ b/contracts/Overtime/SportsAMMV2Data.sol
@@ -45,7 +45,6 @@ contract SportsAMMV2Data is Initializable, ProxyOwned, ProxyPausable {
         MarketData[] marketsData;
         MarketResult[] marketsResult;
         address ticketOwner;
-        address ticketCreator;
         uint buyInAmount;
         uint fees;
         uint totalQuote;
@@ -124,7 +123,6 @@ contract SportsAMMV2Data is Initializable, ProxyOwned, ProxyPausable {
                 marketsData,
                 marketsResult,
                 ticket.ticketOwner(),
-                ticket.ticketCreator(),
                 ticket.buyInAmount(),
                 ticket.fees(),
                 ticket.totalQuote(),

--- a/contracts/Overtime/Ticket.sol
+++ b/contracts/Overtime/Ticket.sol
@@ -205,8 +205,8 @@ contract Ticket is OwnedWithInit {
 
     /// @notice expire ticket
     function expire(address payable beneficiary) external onlyAMM {
-        require(phase() == Phase.Expiry, "Ticket expired");
-        require(!resolved, "Can't expire resolved parlay.");
+        require(phase() == Phase.Expiry, "Ticket not in expiry phase");
+        require(!resolved, "Can't expire resolved ticket");
         emit Expired(beneficiary);
         _selfDestruct(beneficiary);
     }

--- a/contracts/Overtime/Ticket.sol
+++ b/contracts/Overtime/Ticket.sol
@@ -221,7 +221,7 @@ contract Ticket is OwnedWithInit {
     function _resolve(bool _hasUserWon, bool _cancelled) internal {
         resolved = true;
         cancelled = _cancelled;
-        sportsAMM.resolveTicket(ticketOwner, _hasUserWon, _cancelled, buyInAmount, ticketCreator, address(collateral));
+        sportsAMM.resolveTicket(ticketOwner, _hasUserWon, _cancelled, buyInAmount, address(collateral));
         emit Resolved(_hasUserWon, _cancelled);
     }
 

--- a/contracts/Overtime/Ticket.sol
+++ b/contracts/Overtime/Ticket.sol
@@ -35,14 +35,12 @@ contract Ticket is OwnedWithInit {
         uint _totalQuote;
         address _sportsAMM;
         address _ticketOwner;
-        address _ticketCreator;
         IERC20 _collateral;
         uint _expiry;
     }
 
     ISportsAMMV2 public sportsAMM;
     address public ticketOwner;
-    address public ticketCreator;
     IERC20 public collateral;
 
     uint public buyInAmount;
@@ -76,7 +74,6 @@ contract Ticket is OwnedWithInit {
         fees = params._fees;
         totalQuote = params._totalQuote;
         ticketOwner = params._ticketOwner;
-        ticketCreator = params._ticketCreator;
         collateral = params._collateral;
         expiry = params._expiry;
         createdAt = block.timestamp;

--- a/contracts/Overtime/Ticket.sol
+++ b/contracts/Overtime/Ticket.sol
@@ -221,7 +221,6 @@ contract Ticket is OwnedWithInit {
     function _resolve(bool _hasUserWon, bool _cancelled) internal {
         resolved = true;
         cancelled = _cancelled;
-        sportsAMM.resolveTicket(ticketOwner, _hasUserWon, _cancelled, buyInAmount, address(collateral));
         emit Resolved(_hasUserWon, _cancelled);
     }
 

--- a/contracts/interfaces/ISportsAMMV2.sol
+++ b/contracts/interfaces/ISportsAMMV2.sol
@@ -47,7 +47,6 @@ interface ISportsAMMV2 {
         bool _hasUserWon,
         bool _cancelled,
         uint _buyInAmount,
-        address _ticketCreator,
         address _collateral
     ) external;
 

--- a/contracts/interfaces/ISportsAMMV2.sol
+++ b/contracts/interfaces/ISportsAMMV2.sol
@@ -42,14 +42,6 @@ interface ISportsAMMV2 {
 
     function safeBoxFee() external view returns (uint);
 
-    function resolveTicket(
-        address _ticketOwner,
-        bool _hasUserWon,
-        bool _cancelled,
-        uint _buyInAmount,
-        address _collateral
-    ) external;
-
     function exerciseTicket(address _ticket) external;
 
     function getTicketsPerGame(uint _index, uint _pageSize, bytes32 _gameId) external view returns (address[] memory);

--- a/scripts/abi/ISportsAMMV2.json
+++ b/scripts/abi/ISportsAMMV2.json
@@ -193,11 +193,6 @@
       },
       {
         "internalType": "address",
-        "name": "_ticketCreator",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
         "name": "_collateral",
         "type": "address"
       }

--- a/scripts/abi/ISportsAMMV2.json
+++ b/scripts/abi/ISportsAMMV2.json
@@ -170,39 +170,6 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_ticketOwner",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "_hasUserWon",
-        "type": "bool"
-      },
-      {
-        "internalType": "bool",
-        "name": "_cancelled",
-        "type": "bool"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_buyInAmount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "_collateral",
-        "type": "address"
-      }
-    ],
-    "name": "resolveTicket",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "resultManager",
     "outputs": [

--- a/scripts/abi/ISportsAMMV2Manager.json
+++ b/scripts/abi/ISportsAMMV2Manager.json
@@ -50,32 +50,6 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "manager",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "needsTransformingCollateral",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
         "internalType": "uint256",

--- a/scripts/abi/SportsAMMV2.json
+++ b/scripts/abi/SportsAMMV2.json
@@ -973,11 +973,6 @@
       },
       {
         "internalType": "address",
-        "name": "_ticketCreator",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
         "name": "_collateral",
         "type": "address"
       }

--- a/scripts/abi/SportsAMMV2.json
+++ b/scripts/abi/SportsAMMV2.json
@@ -950,39 +950,6 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_ticketOwner",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "_hasUserWon",
-        "type": "bool"
-      },
-      {
-        "internalType": "bool",
-        "name": "_cancelled",
-        "type": "bool"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_buyInAmount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "_collateral",
-        "type": "address"
-      }
-    ],
-    "name": "resolveTicket",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "resultManager",
     "outputs": [
@@ -1043,25 +1010,6 @@
   {
     "inputs": [],
     "name": "safeBoxFee",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "safeBoxFeePerAddress",
     "outputs": [
       {
         "internalType": "uint256",

--- a/scripts/abi/SportsAMMV2Data.json
+++ b/scripts/abi/SportsAMMV2Data.json
@@ -209,11 +209,6 @@
             "type": "address"
           },
           {
-            "internalType": "address",
-            "name": "ticketCreator",
-            "type": "address"
-          },
-          {
             "internalType": "uint256",
             "name": "buyInAmount",
             "type": "uint256"
@@ -388,11 +383,6 @@
           {
             "internalType": "address",
             "name": "ticketOwner",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "ticketCreator",
             "type": "address"
           },
           {
@@ -613,11 +603,6 @@
             "type": "address"
           },
           {
-            "internalType": "address",
-            "name": "ticketCreator",
-            "type": "address"
-          },
-          {
             "internalType": "uint256",
             "name": "buyInAmount",
             "type": "uint256"
@@ -792,11 +777,6 @@
           {
             "internalType": "address",
             "name": "ticketOwner",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "ticketCreator",
             "type": "address"
           },
           {

--- a/scripts/abi/SportsAMMV2LiquidityPoolData.json
+++ b/scripts/abi/SportsAMMV2LiquidityPoolData.json
@@ -1,0 +1,331 @@
+[
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerNominated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "PauseChanged",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract SportsAMMV2LiquidityPool",
+        "name": "liquidityPool",
+        "type": "address"
+      }
+    ],
+    "name": "getLiquidityPoolData",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "collateral",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "started",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxAllowedDeposit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "round",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalDeposited",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minDepositAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxAllowedUsers",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "usersCurrentlyInPool",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "canCloseCurrentRound",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "paused",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "roundLength",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "allocationCurrentRound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lifetimePnl",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "roundEndTime",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct SportsAMMV2LiquidityPoolData.LiquidityPoolData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract SportsAMMV2LiquidityPool",
+        "name": "liquidityPool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "getUserLiquidityPoolData",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "balanceCurrentRound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balanceNextRound",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "withdrawalRequested",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "withdrawalShare",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct SportsAMMV2LiquidityPoolData.UserLiquidityPoolData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastPauseTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "nominateNewOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nominatedOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "setOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_paused",
+        "type": "bool"
+      }
+    ],
+    "name": "setPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "proxyAddress",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnershipAtInit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/scripts/abi/Ticket.json
+++ b/scripts/abi/Ticket.json
@@ -372,11 +372,6 @@
             "type": "address"
           },
           {
-            "internalType": "address",
-            "name": "_ticketCreator",
-            "type": "address"
-          },
-          {
             "internalType": "contract IERC20",
             "name": "_collateral",
             "type": "address"
@@ -618,19 +613,6 @@
     "outputs": [
       {
         "internalType": "contract ISportsAMMV2",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "ticketCreator",
-    "outputs": [
-      {
-        "internalType": "address",
         "name": "",
         "type": "address"
       }

--- a/scripts/abi/TicketMastercopy.json
+++ b/scripts/abi/TicketMastercopy.json
@@ -377,11 +377,6 @@
             "type": "address"
           },
           {
-            "internalType": "address",
-            "name": "_ticketCreator",
-            "type": "address"
-          },
-          {
             "internalType": "contract IERC20",
             "name": "_collateral",
             "type": "address"
@@ -623,19 +618,6 @@
     "outputs": [
       {
         "internalType": "contract ISportsAMMV2",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "ticketCreator",
-    "outputs": [
-      {
-        "internalType": "address",
         "name": "",
         "type": "address"
       }

--- a/scripts/deployOvertime/deployLiquidityPool/deploySportsAMMV2LiquidityPoolData.js
+++ b/scripts/deployOvertime/deployLiquidityPool/deploySportsAMMV2LiquidityPoolData.js
@@ -1,0 +1,77 @@
+const { ethers, upgrades } = require('hardhat');
+const { getImplementationAddress, getAdminAddress } = require('@openzeppelin/upgrades-core');
+const { setTargetAddress, getTargetAddress, delay } = require('../../helpers');
+
+async function main() {
+	let accounts = await ethers.getSigners();
+	let owner = accounts[0];
+	let networkObj = await ethers.provider.getNetwork();
+	let network = networkObj.name;
+
+	console.log('Owner is:', owner.address);
+	console.log('Network:', network);
+
+	const protocolDAOAddress = getTargetAddress('ProtocolDAO', network);
+
+	const sportsAMMV2LiquidityPoolData = await ethers.getContractFactory(
+		'SportsAMMV2LiquidityPoolData'
+	);
+	const sportsAMMV2LiquidityPoolDataDeployed = await upgrades.deployProxy(
+		sportsAMMV2LiquidityPoolData,
+		[owner.address],
+		{ initialOwner: protocolDAOAddress }
+	);
+	await sportsAMMV2LiquidityPoolDataDeployed.waitForDeployment();
+
+	const sportsAMMV2LiquidityPoolDataAddress =
+		await sportsAMMV2LiquidityPoolDataDeployed.getAddress();
+
+	console.log('SportsAMMV2LiquidityPoolData deployed on:', sportsAMMV2LiquidityPoolDataAddress);
+	setTargetAddress('SportsAMMV2LiquidityPoolData', network, sportsAMMV2LiquidityPoolDataAddress);
+	await delay(5000);
+
+	const sportsAMMV2LiquidityPoolDataImplementationAddress = await getImplementationAddress(
+		ethers.provider,
+		sportsAMMV2LiquidityPoolDataAddress
+	);
+	console.log(
+		'SportsAMMV2LiquidityPoolData Implementation:',
+		sportsAMMV2LiquidityPoolDataImplementationAddress
+	);
+	setTargetAddress(
+		'SportsAMMV2LiquidityPoolDataImplementation',
+		network,
+		sportsAMMV2LiquidityPoolDataImplementationAddress
+	);
+
+	const sportsAMMV2LiquidityPoolDataProxyAdminAddress = await getAdminAddress(
+		ethers.provider,
+		sportsAMMV2LiquidityPoolDataAddress
+	);
+	console.log(
+		'SportsAMMV2LiquidityPoolData Proxy Admin:',
+		sportsAMMV2LiquidityPoolDataProxyAdminAddress
+	);
+	setTargetAddress(
+		'SportsAMMV2LiquidityPoolDataProxyAdmin',
+		network,
+		sportsAMMV2LiquidityPoolDataProxyAdminAddress
+	);
+
+	await delay(5000);
+
+	try {
+		await hre.run('verify:verify', {
+			address: sportsAMMV2LiquidityPoolDataAddress,
+		});
+	} catch (e) {
+		console.log(e);
+	}
+}
+
+main()
+	.then(() => process.exit(0))
+	.catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});

--- a/scripts/deployments.json
+++ b/scripts/deployments.json
@@ -31,7 +31,10 @@
 		"SportsAMMV2DataProxyAdmin": "0x5736CbB1dEe9ED00633172bf5a8C7Fd47A0Dfc46",
 		"MockChainlinkOracle": "0x13De488552594aAbC5dE42f77A3Ed61f745411BA",
 		"LiveTradingProcessor": "0x54d1EFfa31CF27849fb155b8763b8F23F47326Cb",
-		"ChainlinkResolver": "0xbd0E2A7990126CCE51c47A946162D6DC8F2F2e9c"
+		"ChainlinkResolver": "0xbd0E2A7990126CCE51c47A946162D6DC8F2F2e9c",
+		"SportsAMMV2LiquidityPoolData": "0xd61FA46d4e3CD47584a56fC20856Fdd197135756",
+		"SportsAMMV2LiquidityPoolDataImplementation": "0xa49A562E226cb47ae7422837E06390e7C6b9Ae17",
+		"SportsAMMV2LiquidityPoolDataProxyAdmin": "0x4d7C8Dbc59E126D97964C10319Da1Fb81Ca28011"
 	},
 	"optimisticEthereum": {
 		"ProtocolDAO": "0xEF2b0A2FFCdCD3b53D81800D19A543136f26a6b8",

--- a/test/contracts/Overtime/SportsAMMV2Data/DeploymentAndSetters.js
+++ b/test/contracts/Overtime/SportsAMMV2Data/DeploymentAndSetters.js
@@ -6,10 +6,10 @@ const {
 } = require('../../../utils/fixtures/overtimeFixtures');
 
 describe('SportsAMMV2Data Deployment And Setters', () => {
-	let sportsAMMV2Data, sportsAMMV2, riskManager, owner, secondAccount, thirdAccount;
+	let sportsAMMV2Data, sportsAMMV2, sportsAMMV2RiskManager, owner, secondAccount, thirdAccount;
 
 	beforeEach(async () => {
-		({ sportsAMMV2Data, sportsAMMV2, riskManager, owner } =
+		({ sportsAMMV2Data, sportsAMMV2, sportsAMMV2RiskManager, owner } =
 			await loadFixture(deploySportsAMMV2Fixture));
 		({ secondAccount, thirdAccount } = await loadFixture(deployAccountsFixture));
 	});
@@ -24,7 +24,9 @@ describe('SportsAMMV2Data Deployment And Setters', () => {
 		});
 
 		it('Should set the right risk manager', async () => {
-			expect(await sportsAMMV2Data.riskManager()).to.equal(await riskManager.getAddress());
+			expect(await sportsAMMV2Data.riskManager()).to.equal(
+				await sportsAMMV2RiskManager.getAddress()
+			);
 		});
 	});
 

--- a/test/contracts/Overtime/SportsAMMV2Data/DeploymentAndSetters.js
+++ b/test/contracts/Overtime/SportsAMMV2Data/DeploymentAndSetters.js
@@ -6,10 +6,11 @@ const {
 } = require('../../../utils/fixtures/overtimeFixtures');
 
 describe('SportsAMMV2Data Deployment And Setters', () => {
-	let sportsAMMV2Data, sportsAMMV2, owner, secondAccount, thirdAccount;
+	let sportsAMMV2Data, sportsAMMV2, riskManager, owner, secondAccount, thirdAccount;
 
 	beforeEach(async () => {
-		({ sportsAMMV2Data, sportsAMMV2, owner } = await loadFixture(deploySportsAMMV2Fixture));
+		({ sportsAMMV2Data, sportsAMMV2, riskManager, owner } =
+			await loadFixture(deploySportsAMMV2Fixture));
 		({ secondAccount, thirdAccount } = await loadFixture(deployAccountsFixture));
 	});
 
@@ -20,6 +21,10 @@ describe('SportsAMMV2Data Deployment And Setters', () => {
 
 		it('Should set the right Sports AMM', async () => {
 			expect(await sportsAMMV2Data.sportsAMM()).to.equal(await sportsAMMV2.getAddress());
+		});
+
+		it('Should set the right risk manager', async () => {
+			expect(await sportsAMMV2Data.riskManager()).to.equal(await riskManager.getAddress());
 		});
 	});
 

--- a/test/contracts/Overtime/SportsAMMV2Data/ReadData.js
+++ b/test/contracts/Overtime/SportsAMMV2Data/ReadData.js
@@ -94,7 +94,6 @@ describe('SportsAMMV2Data Read Data', () => {
 			expect(ticketsData[0].marketsResult.length).to.be.equal(numberOfGamesOnTicket);
 			expect(ticketsData[0].resolved).to.be.equal(false);
 			expect(ticketsData[0].ticketOwner).to.be.equal(firstTraderAddress);
-			expect(ticketsData[0].ticketCreator).to.be.equal(firstTraderAddress);
 		});
 
 		it('Should return resolved tickets data per user', async () => {
@@ -119,7 +118,6 @@ describe('SportsAMMV2Data Read Data', () => {
 			expect(ticketsData[0].isLost).to.be.equal(true);
 			expect(ticketsData[0].isUserTheWinner).to.be.equal(false);
 			expect(ticketsData[0].ticketOwner).to.be.equal(firstTraderAddress);
-			expect(ticketsData[0].ticketCreator).to.be.equal(firstTraderAddress);
 		});
 
 		it('Should return tickets data per game', async () => {

--- a/test/contracts/Overtime/SportsAMMV2LiquidityPoolData/DeploymentAndSetters.js
+++ b/test/contracts/Overtime/SportsAMMV2LiquidityPoolData/DeploymentAndSetters.js
@@ -1,0 +1,17 @@
+const { loadFixture } = require('@nomicfoundation/hardhat-toolbox/network-helpers');
+const { expect } = require('chai');
+const { deploySportsAMMV2Fixture } = require('../../../utils/fixtures/overtimeFixtures');
+
+describe('SportsAMMV2LiquidityPoolData Deployment And Setters', () => {
+	let sportsAMMV2Data, owner;
+
+	beforeEach(async () => {
+		({ sportsAMMV2Data, owner } = await loadFixture(deploySportsAMMV2Fixture));
+	});
+
+	describe('Deployment', () => {
+		it('Should set the right owner', async () => {
+			expect(await sportsAMMV2Data.owner()).to.equal(owner.address);
+		});
+	});
+});

--- a/test/contracts/Overtime/SportsAMMV2LiquidityPoolData/ReadData.js
+++ b/test/contracts/Overtime/SportsAMMV2LiquidityPoolData/ReadData.js
@@ -1,0 +1,41 @@
+const { loadFixture } = require('@nomicfoundation/hardhat-toolbox/network-helpers');
+const { expect } = require('chai');
+const {
+	deploySportsAMMV2Fixture,
+	deployAccountsFixture,
+} = require('../../../utils/fixtures/overtimeFixtures');
+
+describe('SportsAMMV2LiquidityPoolData Read Data', () => {
+	let sportsAMMV2LiquidityPoolData, sportsAMMV2LiquidityPool;
+
+	beforeEach(async () => {
+		({ sportsAMMV2LiquidityPoolData, sportsAMMV2LiquidityPool } =
+			await loadFixture(deploySportsAMMV2Fixture));
+		({ firstLiquidityProvider } = await loadFixture(deployAccountsFixture));
+
+		await sportsAMMV2LiquidityPool
+			.connect(firstLiquidityProvider)
+			.deposit(ethers.parseEther('1000'));
+		await sportsAMMV2LiquidityPool.start();
+	});
+
+	describe('Sports AMM liquidity pool data', () => {
+		it('Should return liquidity pool data', async () => {
+			const liquidityPoolData =
+				await sportsAMMV2LiquidityPoolData.getLiquidityPoolData(sportsAMMV2LiquidityPool);
+
+			expect(liquidityPoolData.started).to.be.equal(true);
+			expect(liquidityPoolData.round).to.be.equal(2);
+			expect(liquidityPoolData.totalDeposited).to.be.equal(ethers.parseEther('1000'));
+		});
+
+		it('Should return user liquidity pool data', async () => {
+			const liquidityPoolData = await sportsAMMV2LiquidityPoolData.getUserLiquidityPoolData(
+				sportsAMMV2LiquidityPool,
+				firstLiquidityProvider
+			);
+
+			expect(liquidityPoolData.balanceCurrentRound).to.be.equal(ethers.parseEther('1000'));
+		});
+	});
+});

--- a/test/utils/fixtures/overtimeFixtures.js
+++ b/test/utils/fixtures/overtimeFixtures.js
@@ -370,6 +370,14 @@ async function deploySportsAMMV2Fixture() {
 		sportsAMMV2RiskManagerAddress,
 	]);
 
+	// deploy Sports AMM liqudity pool Data
+	const SportsAMMV2LiquidityPoolData = await ethers.getContractFactory(
+		'SportsAMMV2LiquidityPoolData'
+	);
+	const sportsAMMV2LiquidityPoolData = await upgrades.deployProxy(SportsAMMV2LiquidityPoolData, [
+		owner.address,
+	]);
+
 	const root = await createMerkleTree();
 	const {
 		tradeDataCurrentRound,
@@ -649,6 +657,7 @@ async function deploySportsAMMV2Fixture() {
 		sameGameSamePlayersDifferentProps,
 		chainlinkResolver,
 		tradeDataNotActive,
+		sportsAMMV2LiquidityPoolData,
 	};
 }
 


### PR DESCRIPTION
- Remove circular dependency between SportsAMM and Ticket contract
- Remove `ticketCreator`, use only `ticketOwner`
- Check balances for fees distribution in case some parameters are changed from ticket creation
- Send funds to `msg.sender` (instead of safeBox) in `expireTickets` method 
- Add LP Data contract