### PR TITLE
added support for collaterals with extra payout and dedicated safe box

### DIFF
--- a/contracts/Overtime/LiquidityPool/SportsAMMV2LiquidityPool.sol
+++ b/contracts/Overtime/LiquidityPool/SportsAMMV2LiquidityPool.sol
@@ -415,7 +415,9 @@ contract SportsAMMV2LiquidityPool is Initializable, ProxyOwned, PausableUpgradea
             (!withdrawalRequested[_user] || withdrawalShare[_user] > 0);
     }
 
+    /// @notice return the price of the pool collateral
     function getCollateralPrice() public view returns (uint) {
+        //TODO: add static price of THALES in the price feed contract
         return IPriceFeed(addressManager.getAddress("PriceFeed")).rateForCurrency(collateralKey);
     }
 

--- a/scripts/abi/SportsAMMV2.json
+++ b/scripts/abi/SportsAMMV2.json
@@ -347,6 +347,25 @@
       {
         "indexed": false,
         "internalType": "address",
+        "name": "_collateral",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_addedPayout",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetAddedPayoutPercentagePerCollateral",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
         "name": "freeBetsHolder",
         "type": "address"
       }
@@ -491,6 +510,25 @@
     "name": "acceptOwnership",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "addedPayoutPercentagePerCollateral",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -841,6 +879,24 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collateral",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_addedPayout",
+        "type": "uint256"
+      }
+    ],
+    "name": "setAddedPayoutPercentagePerCollateral",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {


### PR DESCRIPTION
Added additional payout per collateral as an option. its applied to each market on a ticket. E.g. 1% extra on each game is about 10.3% payout on a 10 leg ticket.
Also added a dedicated SafeBox per collateral, so that THALES can be decoupled from staking contract and burned subsequently