### PR TITLE
fix an issue with cancelled games being claimed in future

### DIFF
--- a/contracts/Overtime/LiquidityPool/SportsAMMV2LiquidityPool.sol
+++ b/contracts/Overtime/LiquidityPool/SportsAMMV2LiquidityPool.sol
@@ -209,6 +209,11 @@ contract SportsAMMV2LiquidityPool is Initializable, ProxyOwned, PausableUpgradea
     /// @param _ticket to trade
     function transferToPool(address _ticket, uint _amount) external whenNotPaused roundClosingNotPrepared onlyAMM {
         uint ticketRound = getTicketRound(_ticket);
+
+        // if this is a past round, but not the default one, then we send the funds to the current round
+        if (ticketRound > 1 && ticketRound < round) {
+            ticketRound = round;
+        }
         address liquidityPoolRound = ticketRound <= 1 ? defaultLiquidityProvider : _getOrCreateRoundPool(ticketRound);
         collateral.safeTransferFrom(address(sportsAMM), liquidityPoolRound, _amount);
         if (isTradingTicketInARound[ticketRound][_ticket]) {

--- a/contracts/Overtime/SportsAMMV2.sol
+++ b/contracts/Overtime/SportsAMMV2.sol
@@ -620,7 +620,6 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
         }
 
         // if the ticket was lost or if for any reason there is surplus in SportsAMM after the ticket is exercised, send it all to Liquidity Pool
-        // TODO: if a game was cancelled a certain amount needs to be sent back to LP pool for that round, but in theory that round can be closed, so its better to always send to the active round
         uint amount = ticketCollateral.balanceOf(address(this));
         if (amount > 0) {
             ISportsAMMV2LiquidityPool(liquidityPoolForCollateral[address(ticketCollateral)]).transferToPool(_ticket, amount);


### PR DESCRIPTION
If a game is cancelled the payout is a bit lower than what the ticket was collaterized with. 
In such a case, when user claims ,the difference is sent back to the liquidity pool round for that ticket.
The issue here is that a user can claim e.g. after one month, which effectively sends the funds into a round that ended a month ago. We can use admin methods to pull those funds, but a better solution for now is to send the funds always to the current round