### PR TITLE
System bets

### DIFF
--- a/contracts/core/AMM/SportsAMMV2.sol
+++ b/contracts/core/AMM/SportsAMMV2.sol
@@ -279,7 +279,7 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
         uint _systemBetDenominator
     ) external payable nonReentrant notPaused returns (address _createdTicket) {
         require(
-            _systemBetDenominator > 1 && _systemBetDenominator < _tradeData.length - 1,
+            _systemBetDenominator > 1 && _systemBetDenominator < _tradeData.length,
             "_systemBetDenominator value out of range"
         );
         _createdTicket = _tradeInternal(
@@ -536,21 +536,19 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
                     _tradeDataInternal._isLive
                 )
             );
-        } else {
             if (_systemBetDenominator > 1) {
-                vars._payout = riskManager.getMaxSystemBetPayout(
+                (vars._payout, vars._totalQuote) = riskManager.getMaxSystemBetPayout(
                     _tradeData,
-                    _tradeDataInternal._buyInAmount,
-                    _systemBetDenominator
+                    _systemBetDenominator,
+                    _tradeDataInternal._buyInAmount
                 );
-                vars._totalQuote = (ONE * _tradeDataInternal._buyInAmount) / vars._payout;
-            } else {
-                vars._totalQuote = (ONE * _tradeDataInternal._buyInAmount) / _tradeDataInternal._expectedPayout;
-                vars._totalQuote =
-                    (vars._totalQuote * ONE) /
-                    ((ONE + vars._addedPayoutPercentage) - (vars._addedPayoutPercentage * vars._totalQuote) / ONE);
-                vars._payout = (ONE * _tradeDataInternal._buyInAmount) / vars._totalQuote;
             }
+        } else {
+            vars._totalQuote = (ONE * _tradeDataInternal._buyInAmount) / _tradeDataInternal._expectedPayout;
+            vars._totalQuote =
+                (vars._totalQuote * ONE) /
+                ((ONE + vars._addedPayoutPercentage) - (vars._addedPayoutPercentage * vars._totalQuote) / ONE);
+            vars._payout = (ONE * _tradeDataInternal._buyInAmount) / vars._totalQuote;
             vars._fees = _getFees(_tradeDataInternal._buyInAmount);
         }
 

--- a/contracts/core/AMM/SportsAMMV2.sol
+++ b/contracts/core/AMM/SportsAMMV2.sol
@@ -556,7 +556,7 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
 
         vars._payoutWithFees = vars._payout + vars._fees;
 
-        _checkRisksLimitsAndUpdateStakingVolume(_tradeData, vars._totalQuote, vars._payout, _tradeDataInternal);
+        checkRisksLimits(_tradeData, vars._totalQuote, vars._payout, _tradeDataInternal);
 
         // Clone a ticket
         Ticket.MarketData[] memory markets = _getTicketMarkets(_tradeData, vars._addedPayoutPercentage);
@@ -615,7 +615,7 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
     }
 
     // Checks risk and updates Staking Volume
-    function _checkRisksLimitsAndUpdateStakingVolume(
+    function checkRisksLimits(
         ISportsAMMV2.TradeData[] memory _tradeData,
         uint _totalQuote,
         uint _payout,
@@ -649,13 +649,6 @@ contract SportsAMMV2 is Initializable, ProxyOwned, ProxyPausable, ProxyReentranc
             _tradeDataInternal._additionalSlippage,
             _tradeData.length
         );
-        if (address(stakingThales) != address(0)) {
-            stakingThales.updateVolumeAtAmountDecimals(
-                _tradeDataInternal._recipient,
-                _buyInAmount,
-                defaultCollateralDecimals
-            );
-        }
     }
 
     function _getTicketMarkets(

--- a/contracts/core/AMM/SportsAMMV2RiskManager.sol
+++ b/contracts/core/AMM/SportsAMMV2RiskManager.sol
@@ -273,12 +273,13 @@ contract SportsAMMV2RiskManager is Initializable, ProxyOwned, ProxyPausable, Pro
      * @param _systemBetDenominator The system bet denominator to adjust the payout calculation.
      * @param _buyInAmount The amount of collateral staked by the user in the system bet.
      * @return systemBetPayout The calculated payout amount based on the input parameters.
+     * @return systemBetQuote The calculated quote odds based on the input parameters.
      */
     function getMaxSystemBetPayout(
         ISportsAMMV2.TradeData[] memory _tradeData,
         uint _systemBetDenominator,
         uint _buyInAmount
-    ) external pure returns (uint systemBetPayout) {
+    ) external pure returns (uint systemBetPayout, uint systemBetQuote) {
         uint[][] memory systemCombinations = generateCombinations(_tradeData.length, _systemBetDenominator);
         uint totalCombinations = systemCombinations.length;
         uint buyinPerCombination = ((_buyInAmount * ONE) / totalCombinations) / ONE;
@@ -300,17 +301,18 @@ contract SportsAMMV2RiskManager is Initializable, ProxyOwned, ProxyPausable, Pro
                 systemBetPayout += combinationPayout;
             }
         }
+        systemBetQuote = (ONE * _buyInAmount) / systemBetPayout;
     }
 
     /* ========== SYSTEM BET UTILS ========== */
 
     function generateCombinations(uint n, uint k) public pure returns (uint[][] memory) {
-        require(k <= n, "k cannot be greater than n");
+        require(k > 1 && k < n, "k has to be greater than 1 and less than n");
 
         // Dynamically create the elements array [1, 2, ..., n]
         uint[] memory elements = new uint[](n);
         for (uint i = 0; i < n; i++) {
-            elements[i] = i + 1; // 1-based indexing
+            elements[i] = i; // 0-based indexing
         }
 
         uint combinationsCount = factorial(n) / (factorial(k) * factorial(n - k)); // Calculate the number of combinations

--- a/contracts/core/AMM/Ticket.sol
+++ b/contracts/core/AMM/Ticket.sol
@@ -39,6 +39,7 @@ contract Ticket {
         IERC20 _collateral;
         uint _expiry;
         bool _isLive;
+        uint _systemBetDenominator;
     }
 
     ISportsAMMV2 public sportsAMM;
@@ -63,6 +64,12 @@ contract Ticket {
 
     uint public finalPayout;
 
+    bool public isSystem;
+
+    uint systemBetDenominator;
+
+    uint[][] public systemCombinations;
+
     /* ========== CONSTRUCTOR ========== */
 
     /// @notice initialize the ticket contract
@@ -83,6 +90,10 @@ contract Ticket {
         expiry = params._expiry;
         isLive = params._isLive;
         createdAt = block.timestamp;
+        systemBetDenominator = params._systemBetDenominator;
+        if (systemBetDenominator > 0) {
+            systemCombinations = sportsAMM.riskManager().generateCombinations(numOfMarkets, systemBetDenominator);
+        }
     }
 
     /* ========== EXTERNAL READ FUNCTIONS ========== */
@@ -90,6 +101,7 @@ contract Ticket {
     /// @notice checks if the user lost the ticket
     /// @return isTicketLost true/false
     function isTicketLost() public view returns (bool) {
+        uint lostMarketsCount = 0;
         for (uint i = 0; i < numOfMarkets; i++) {
             bool isMarketResolved = sportsAMM.resultManager().isMarketResolved(
                 markets[i].gameId,
@@ -107,7 +119,14 @@ contract Ticket {
                 markets[i].combinedPositions
             );
             if (isMarketResolved && !isWinningMarketPosition) {
-                return true;
+                if (!isSystem) {
+                    return true;
+                } else {
+                    lostMarketsCount++;
+                    if (lostMarketsCount > (numOfMarkets - systemBetDenominator)) {
+                        return true;
+                    }
+                }
             }
         }
         return false;
@@ -189,9 +208,15 @@ contract Ticket {
                     isCancelled = false;
                 }
             }
+
+            if (isSystem && !isCancelled) {
+                finalPayout = _getSystemBetPayout();
+            }
+
             if (isCancelled) {
                 finalPayout = buyInAmount;
             }
+
             collateral.safeTransfer(
                 _exerciseCollateral == address(0) || _exerciseCollateral == address(collateral)
                     ? address(ticketOwner)
@@ -267,6 +292,70 @@ contract Ticket {
         if (paused == _paused) return;
         paused = _paused;
         emit PauseUpdated(_paused);
+    }
+
+    /* ========== SYSTEM BET UTILS ========== */
+
+    function _getSystemBetPayout() internal view returns (uint systemBetPayout) {
+        uint totalCombinations = systemCombinations.length;
+        uint buyinPerCombination = ((buyInAmount * ONE) / totalCombinations) / ONE;
+
+        bool[] memory winningMarkets = new bool[](numOfMarkets);
+        bool[] memory cancelledMarkets = new bool[](numOfMarkets);
+        bool[] memory resolvedMarkets = new bool[](numOfMarkets);
+
+        for (uint i = 0; i < numOfMarkets; i++) {
+            resolvedMarkets[i] = sportsAMM.resultManager().isMarketResolved(
+                markets[i].gameId,
+                markets[i].typeId,
+                markets[i].playerId,
+                markets[i].line,
+                markets[i].combinedPositions
+            );
+            winningMarkets[i] = sportsAMM.resultManager().isWinningMarketPosition(
+                markets[i].gameId,
+                markets[i].typeId,
+                markets[i].playerId,
+                markets[i].line,
+                markets[i].position,
+                markets[i].combinedPositions
+            );
+
+            cancelledMarkets[i] = sportsAMM.resultManager().isCancelledMarketPosition(
+                markets[i].gameId,
+                markets[i].typeId,
+                markets[i].playerId,
+                markets[i].line,
+                markets[i].position,
+                markets[i].combinedPositions
+            );
+        }
+
+        // Loop through each stored combination
+        for (uint i = 0; i < totalCombinations; i++) {
+            uint[] memory currentCombination = systemCombinations[i];
+
+            uint combinationQuote;
+
+            for (uint j = 0; j < currentCombination.length; j++) {
+                uint marketIndex = currentCombination[j];
+                if (winningMarkets[marketIndex]) {
+                    if (!cancelledMarkets[marketIndex]) {
+                        combinationQuote = combinationQuote == 0
+                            ? markets[marketIndex].odd
+                            : (combinationQuote * markets[marketIndex].odd) / ONE;
+                    }
+                } else {
+                    combinationQuote = 0;
+                    break;
+                }
+            }
+
+            if (combinationQuote > 0) {
+                uint combinationPayout = (buyinPerCombination * ONE) / combinationQuote;
+                systemBetPayout += combinationPayout;
+            }
+        }
     }
 
     /* ========== MODIFIERS ========== */

--- a/contracts/interfaces/ISportsAMMV2RiskManager.sol
+++ b/contracts/interfaces/ISportsAMMV2RiskManager.sol
@@ -75,4 +75,12 @@ interface ISportsAMMV2RiskManager {
     function verifyMerkleTree(ISportsAMMV2.TradeData memory _marketTradeData, bytes32 _rootPerGame) external pure;
 
     function isSportIdFuture(uint16 _sportsId) external view returns (bool);
+
+    function getMaxSystemBetPayout(
+        ISportsAMMV2.TradeData[] memory _tradeData,
+        uint _systemBetDenominator,
+        uint _buyInAmount
+    ) external pure returns (uint systemBetPayout);
+
+    function generateCombinations(uint n, uint k) external pure returns (uint[][] memory);
 }

--- a/contracts/interfaces/ISportsAMMV2RiskManager.sol
+++ b/contracts/interfaces/ISportsAMMV2RiskManager.sol
@@ -80,7 +80,7 @@ interface ISportsAMMV2RiskManager {
         ISportsAMMV2.TradeData[] memory _tradeData,
         uint _systemBetDenominator,
         uint _buyInAmount
-    ) external pure returns (uint systemBetPayout);
+    ) external pure returns (uint systemBetPayout, uint systemBetQuote);
 
     function generateCombinations(uint n, uint k) external pure returns (uint[][] memory);
 }

--- a/scripts/abi/ISportsAMMV2RiskManager.json
+++ b/scripts/abi/ISportsAMMV2RiskManager.json
@@ -307,6 +307,133 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "n",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "k",
+        "type": "uint256"
+      }
+    ],
+    "name": "generateCombinations",
+    "outputs": [
+      {
+        "internalType": "uint256[][]",
+        "name": "",
+        "type": "uint256[][]"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "gameId",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint16",
+            "name": "sportId",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint16",
+            "name": "typeId",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maturity",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint8",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "int24",
+            "name": "line",
+            "type": "int24"
+          },
+          {
+            "internalType": "uint24",
+            "name": "playerId",
+            "type": "uint24"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "odds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "merkleProof",
+            "type": "bytes32[]"
+          },
+          {
+            "internalType": "uint8",
+            "name": "position",
+            "type": "uint8"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint16",
+                "name": "typeId",
+                "type": "uint16"
+              },
+              {
+                "internalType": "uint8",
+                "name": "position",
+                "type": "uint8"
+              },
+              {
+                "internalType": "int24",
+                "name": "line",
+                "type": "int24"
+              }
+            ],
+            "internalType": "struct ISportsAMMV2.CombinedPosition[][]",
+            "name": "combinedPositions",
+            "type": "tuple[][]"
+          }
+        ],
+        "internalType": "struct ISportsAMMV2.TradeData[]",
+        "name": "_tradeData",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_systemBetDenominator",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_buyInAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "getMaxSystemBetPayout",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "systemBetPayout",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint16",
         "name": "_sportsId",
         "type": "uint16"

--- a/scripts/abi/ISportsAMMV2RiskManager.json
+++ b/scripts/abi/ISportsAMMV2RiskManager.json
@@ -426,6 +426,11 @@
         "internalType": "uint256",
         "name": "systemBetPayout",
         "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "systemBetQuote",
+        "type": "uint256"
       }
     ],
     "stateMutability": "pure",

--- a/scripts/abi/SportsAMMV2.json
+++ b/scripts/abi/SportsAMMV2.json
@@ -1646,6 +1646,134 @@
   {
     "inputs": [
       {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "gameId",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint16",
+            "name": "sportId",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint16",
+            "name": "typeId",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maturity",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint8",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "int24",
+            "name": "line",
+            "type": "int24"
+          },
+          {
+            "internalType": "uint24",
+            "name": "playerId",
+            "type": "uint24"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "odds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "merkleProof",
+            "type": "bytes32[]"
+          },
+          {
+            "internalType": "uint8",
+            "name": "position",
+            "type": "uint8"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint16",
+                "name": "typeId",
+                "type": "uint16"
+              },
+              {
+                "internalType": "uint8",
+                "name": "position",
+                "type": "uint8"
+              },
+              {
+                "internalType": "int24",
+                "name": "line",
+                "type": "int24"
+              }
+            ],
+            "internalType": "struct ISportsAMMV2.CombinedPosition[][]",
+            "name": "combinedPositions",
+            "type": "tuple[][]"
+          }
+        ],
+        "internalType": "struct ISportsAMMV2.TradeData[]",
+        "name": "_tradeData",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_buyInAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_expectedQuote",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_additionalSlippage",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_referrer",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateral",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_systemBetDenominator",
+        "type": "uint256"
+      }
+    ],
+    "name": "tradeSystemBet",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "_createdTicket",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "proxyAddress",
         "type": "address"

--- a/scripts/abi/SportsAMMV2RiskManager.json
+++ b/scripts/abi/SportsAMMV2RiskManager.json
@@ -1001,6 +1001,133 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "n",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "k",
+        "type": "uint256"
+      }
+    ],
+    "name": "generateCombinations",
+    "outputs": [
+      {
+        "internalType": "uint256[][]",
+        "name": "",
+        "type": "uint256[][]"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "gameId",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint16",
+            "name": "sportId",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint16",
+            "name": "typeId",
+            "type": "uint16"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maturity",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint8",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "int24",
+            "name": "line",
+            "type": "int24"
+          },
+          {
+            "internalType": "uint24",
+            "name": "playerId",
+            "type": "uint24"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "odds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "merkleProof",
+            "type": "bytes32[]"
+          },
+          {
+            "internalType": "uint8",
+            "name": "position",
+            "type": "uint8"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint16",
+                "name": "typeId",
+                "type": "uint16"
+              },
+              {
+                "internalType": "uint8",
+                "name": "position",
+                "type": "uint8"
+              },
+              {
+                "internalType": "int24",
+                "name": "line",
+                "type": "int24"
+              }
+            ],
+            "internalType": "struct ISportsAMMV2.CombinedPosition[][]",
+            "name": "combinedPositions",
+            "type": "tuple[][]"
+          }
+        ],
+        "internalType": "struct ISportsAMMV2.TradeData[]",
+        "name": "_tradeData",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_systemBetDenominator",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_buyInAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "getMaxSystemBetPayout",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "systemBetPayout",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256[]",
         "name": "_sportIds",
         "type": "uint256[]"

--- a/scripts/abi/SportsAMMV2RiskManager.json
+++ b/scripts/abi/SportsAMMV2RiskManager.json
@@ -1120,6 +1120,11 @@
         "internalType": "uint256",
         "name": "systemBetPayout",
         "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "systemBetQuote",
+        "type": "uint256"
       }
     ],
     "stateMutability": "pure",

--- a/scripts/abi/Ticket.json
+++ b/scripts/abi/Ticket.json
@@ -268,6 +268,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "getSystemBetPayout",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "systemBetPayout",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "components": [

--- a/scripts/abi/Ticket.json
+++ b/scripts/abi/Ticket.json
@@ -384,6 +384,11 @@
             "internalType": "bool",
             "name": "_isLive",
             "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "_systemBetDenominator",
+            "type": "uint256"
           }
         ],
         "internalType": "struct Ticket.TicketInit",
@@ -412,6 +417,19 @@
   {
     "inputs": [],
     "name": "isLive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isSystem",
     "outputs": [
       {
         "internalType": "bool",
@@ -593,6 +611,30 @@
         "internalType": "contract ISportsAMMV2",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "systemCombinations",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/scripts/abi/TicketMastercopy.json
+++ b/scripts/abi/TicketMastercopy.json
@@ -389,6 +389,11 @@
             "internalType": "bool",
             "name": "_isLive",
             "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "_systemBetDenominator",
+            "type": "uint256"
           }
         ],
         "internalType": "struct Ticket.TicketInit",
@@ -417,6 +422,19 @@
   {
     "inputs": [],
     "name": "isLive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isSystem",
     "outputs": [
       {
         "internalType": "bool",
@@ -598,6 +616,30 @@
         "internalType": "contract ISportsAMMV2",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "systemCombinations",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/scripts/abi/TicketMastercopy.json
+++ b/scripts/abi/TicketMastercopy.json
@@ -273,6 +273,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "getSystemBetPayout",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "systemBetPayout",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "components": [

--- a/test/contracts/Overtime/SportsAMMV2LiquidityPoolETH/TradeUsingSixDecimalCollateral.js
+++ b/test/contracts/Overtime/SportsAMMV2LiquidityPoolETH/TradeUsingSixDecimalCollateral.js
@@ -743,8 +743,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT);
 			// // difference between payout and buy-in (amount taken from LP)
 			// // payout: 20
 			// // fees: 0.2
@@ -945,8 +943,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT_SIX_DECIMALS);
 			// // difference between payout and buy-in (amount taken from LP)
 			// // payout: 20
 			// // fees: 0.2
@@ -1166,8 +1162,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT);
 			// // difference between payout and buy-in (amount taken from LP)
 			// // payout: 20
 			// // fees: 0.2
@@ -1408,8 +1402,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT_SIX_DECIMALS);
 			// // difference between payout and buy-in (amount taken from LP)
 			// // payout: 20
 			// // fees: 0.2
@@ -1612,9 +1604,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT_SIX_DECIMALS);
-
 			// difference between payout and buy-in (amount taken from LP)
 			// payout: 20
 			// fees: 0.2
@@ -1809,9 +1798,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT);
-
 			// difference between payout and buy-in (amount taken from LP)
 			// payout: 20
 			// fees: 0.2
@@ -2001,9 +1987,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					{ value: ETH_BUY_IN_AMOUNT }
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(BUY_IN_AMOUNT).to.be.lessThanOrEqual(volumeFirstTrader);
-
 			// // difference between payout and buy-in (amount taken from LP)
 			// // buy-in without fees: 9.8
 			// // payout: 20
@@ -2168,9 +2151,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					true,
 					{ value: ETH_BUY_IN_AMOUNT }
 				);
-
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(BUY_IN_AMOUNT_SIX_DECIMALS).to.be.lessThanOrEqual(volumeFirstTrader);
 
 			// // difference between payout and buy-in (amount taken from LP)
 			// // buy-in without fees: 9.8
@@ -2379,8 +2359,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT_SIX_DECIMALS);
 			// // difference between payout and buy-in (amount taken from LP)
 			// // payout: 20
 			// // fees: 0.2
@@ -2598,8 +2576,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT);
 			// // difference between payout and buy-in (amount taken from LP)
 			// // payout: 20
 			// // fees: 0.2
@@ -2821,8 +2797,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT_SIX_DECIMALS);
 			// // difference between payout and buy-in (amount taken from LP)
 			// // payout: 20
 			// // fees: 0.2
@@ -3042,8 +3016,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT);
 			// // difference between payout and buy-in (amount taken from LP)
 			// // payout: 20
 			// // fees: 0.2
@@ -3238,8 +3210,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT_SIX_DECIMALS);
 			// difference between payout and buy-in (amount taken from LP)
 			// payout: 20
 			// fees: 0.2
@@ -3413,8 +3383,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT);
 			// difference between payout and buy-in (amount taken from LP)
 			// payout: 20
 			// fees: 0.2
@@ -3577,8 +3545,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT_SIX_DECIMALS);
 			// difference between payout and buy-in (amount taken from LP)
 			// payout: 20
 			// fees: 0.2
@@ -3741,8 +3707,6 @@ describe('SportsAMMV2LiquidityPool Six decimal - Trades', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT);
 			// difference between payout and buy-in (amount taken from LP)
 			// payout: 20
 			// fees: 0.2

--- a/test/contracts/Overtime/SportsAMMV2SystemBets/combinationsChecker.js
+++ b/test/contracts/Overtime/SportsAMMV2SystemBets/combinationsChecker.js
@@ -1,0 +1,75 @@
+const { loadFixture, time } = require('@nomicfoundation/hardhat-toolbox/network-helpers');
+const { expect } = require('chai');
+const {
+	deploySportsAMMV2Fixture,
+	deployAccountsFixture,
+} = require('../../../utils/fixtures/overtimeFixtures');
+const { BUY_IN_AMOUNT, ADDITIONAL_SLIPPAGE, SPORT_ID_NBA } = require('../../../constants/overtime');
+const { ZERO_ADDRESS, ONE_WEEK_IN_SECS } = require('../../../constants/general');
+
+describe('SportsAMMV2RiskManager Check And Update Risks', () => {
+	let sportsAMMV2RiskManager,
+		sportsAMMV2,
+		sportsAMMV2LiquidityPool,
+		tradeDataCurrentRound,
+		tradeDataTenMarketsCurrentRound,
+		sameGameDifferentPlayersDifferentProps,
+		firstTrader,
+		firstLiquidityProvider,
+		tradeDataNotActive;
+
+	beforeEach(async () => {
+		({
+			sportsAMMV2RiskManager,
+			sportsAMMV2,
+			sportsAMMV2LiquidityPool,
+			tradeDataCurrentRound,
+			tradeDataTenMarketsCurrentRound,
+			sameGameDifferentPlayersDifferentProps,
+			tradeDataNotActive,
+		} = await loadFixture(deploySportsAMMV2Fixture));
+		({ firstTrader, firstLiquidityProvider } = await loadFixture(deployAccountsFixture));
+
+		await sportsAMMV2LiquidityPool
+			.connect(firstLiquidityProvider)
+			.deposit(ethers.parseEther('5000'));
+		await sportsAMMV2LiquidityPool.start();
+		await sportsAMMV2LiquidityPool.setUtilizationRate(ethers.parseEther('1'));
+	});
+
+	describe('Check combinations generations', () => {
+		it('It should generate 3/5 combinations for system bets as expected)', async () => {
+			let generatedCombinations = await sportsAMMV2RiskManager.generateCombinations(5, 3);
+			expect(generatedCombinations.length).to.equal(10);
+			expect(generatedCombinations[0][0]).to.equal(0);
+			expect(generatedCombinations[0][1]).to.equal(1);
+			expect(generatedCombinations[0][2]).to.equal(2);
+		});
+
+		it('It should generate 7/10 combinations for system bets as expected)', async () => {
+			let generatedCombinations = await sportsAMMV2RiskManager.generateCombinations(10, 7);
+			expect(generatedCombinations.length).to.equal(120);
+			expect(generatedCombinations[119][0]).to.equal(3);
+			expect(generatedCombinations[119][1]).to.equal(4);
+			expect(generatedCombinations[119][2]).to.equal(5);
+			expect(generatedCombinations[119][3]).to.equal(6);
+			expect(generatedCombinations[119][4]).to.equal(7);
+			expect(generatedCombinations[119][5]).to.equal(8);
+			expect(generatedCombinations[119][6]).to.equal(9);
+		});
+
+		it('Should revert if systemBetDenominator is not a proper value)', async () => {
+			await expect(sportsAMMV2RiskManager.generateCombinations(10, 10)).to.be.revertedWith(
+				'k has to be greater than 1 and less than n'
+			);
+
+			await expect(sportsAMMV2RiskManager.generateCombinations(10, 11)).to.be.revertedWith(
+				'k has to be greater than 1 and less than n'
+			);
+
+			await expect(sportsAMMV2RiskManager.generateCombinations(10, 1)).to.be.revertedWith(
+				'k has to be greater than 1 and less than n'
+			);
+		});
+	});
+});

--- a/test/contracts/Overtime/SportsAMMV2SystemBets/systemBets.js
+++ b/test/contracts/Overtime/SportsAMMV2SystemBets/systemBets.js
@@ -1,0 +1,173 @@
+const { loadFixture } = require('@nomicfoundation/hardhat-toolbox/network-helpers');
+const { expect } = require('chai');
+const {
+	deployAccountsFixture,
+	deploySportsAMMV2Fixture,
+} = require('../../../utils/fixtures/overtimeFixtures');
+const {
+	BUY_IN_AMOUNT,
+	ADDITIONAL_SLIPPAGE,
+	RESULT_TYPE,
+	TYPE_ID_TOTAL,
+	TYPE_ID_SPREAD,
+	TYPE_ID_WINNER_TOTAL,
+} = require('../../../constants/overtime');
+const { ZERO_ADDRESS } = require('../../../constants/general');
+
+describe('SportsAMMV2 system bets', () => {
+	let sportsAMMV2,
+		sportsAMMV2RiskManager,
+		sportsAMMV2LiquidityPool,
+		tradeDataCurrentRound,
+		tradeDataTenMarketsCurrentRound,
+		tradeDataThreeMarketsCurrentRound,
+		firstLiquidityProvider,
+		firstTrader,
+		collateral,
+		sportsAMMV2Manager,
+		sportsAMMV2ResultManager,
+		defaultLiquidityProviderAddress,
+		defaultLiquidityProvider;
+
+	beforeEach(async () => {
+		({
+			sportsAMMV2,
+			sportsAMMV2RiskManager,
+			sportsAMMV2Manager,
+			sportsAMMV2LiquidityPool,
+			tradeDataCurrentRound,
+			tradeDataTenMarketsCurrentRound,
+			tradeDataThreeMarketsCurrentRound,
+			collateral,
+			sportsAMMV2ResultManager,
+			defaultLiquidityProvider,
+		} = await loadFixture(deploySportsAMMV2Fixture));
+		({ firstLiquidityProvider, firstTrader } = await loadFixture(deployAccountsFixture));
+
+		defaultLiquidityProviderAddress = await defaultLiquidityProvider.getAddress();
+
+		await sportsAMMV2LiquidityPool
+			.connect(firstLiquidityProvider)
+			.deposit(ethers.parseEther('1000'));
+		await sportsAMMV2LiquidityPool.start();
+	});
+
+	describe('Trade', () => {
+		it('Should buy a system ticket (2/3 markets)', async () => {
+			const quote = await sportsAMMV2.tradeQuote(
+				tradeDataThreeMarketsCurrentRound,
+				BUY_IN_AMOUNT,
+				ZERO_ADDRESS,
+				false
+			);
+
+			expect(quote.payout).to.equal('42735042735042735042');
+
+			const maxSystemBetPayoutAndQuote = await sportsAMMV2RiskManager.getMaxSystemBetPayout(
+				tradeDataThreeMarketsCurrentRound,
+				2,
+				BUY_IN_AMOUNT
+			);
+
+			// console.log('odds0: ' + tradeDataThreeMarketsCurrentRound[0].odds[0] / 1e18); // 0.52 or 1.923 decimal
+			// console.log('odds1: ' + tradeDataThreeMarketsCurrentRound[1].odds[0] / 1e18); // 0.5 or 2 decimal
+			// console.log('odds2: ' + tradeDataThreeMarketsCurrentRound[2].odds[0] / 1e18); // 0.9 or 1.111 decimal
+
+			expect(maxSystemBetPayoutAndQuote.systemBetPayout).to.equal('27350427350427350423');
+
+			await sportsAMMV2
+				.connect(firstTrader)
+				.tradeSystemBet(
+					tradeDataThreeMarketsCurrentRound,
+					BUY_IN_AMOUNT,
+					maxSystemBetPayoutAndQuote.systemBetQuote,
+					ADDITIONAL_SLIPPAGE,
+					ZERO_ADDRESS,
+					ZERO_ADDRESS,
+					false,
+					2
+				);
+
+			const activeTickets = await sportsAMMV2Manager.getActiveTickets(0, 100);
+			const ticketAddress = activeTickets[0];
+
+			const TicketContract = await ethers.getContractFactory('Ticket');
+			const userTicket = await TicketContract.attach(ticketAddress);
+			expect(await userTicket.isSystem()).to.be.equal(true);
+
+			const ticketBalance = await collateral.balanceOf(ticketAddress);
+			expect(ticketBalance).to.equal(ethers.parseEther('27.550427350427350423'));
+
+			expect(await userTicket.isTicketExercisable()).to.be.equal(false);
+
+			await sportsAMMV2ResultManager.setResultTypesPerMarketTypes(
+				[0, TYPE_ID_TOTAL, TYPE_ID_SPREAD, 11029],
+				[
+					RESULT_TYPE.ExactPosition,
+					RESULT_TYPE.OverUnder,
+					RESULT_TYPE.Spread,
+					RESULT_TYPE.OverUnder,
+				]
+			);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[0].gameId],
+				[tradeDataThreeMarketsCurrentRound[0].typeId],
+				[tradeDataThreeMarketsCurrentRound[0].playerId],
+				[[0]]
+			);
+
+			expect(await userTicket.isTicketExercisable()).to.be.equal(false);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[1].gameId],
+				[tradeDataThreeMarketsCurrentRound[1].typeId],
+				[tradeDataThreeMarketsCurrentRound[1].playerId],
+				[[0]]
+			);
+
+			expect(await userTicket.isTicketExercisable()).to.be.equal(false);
+			let systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal(0);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[2].gameId],
+				[tradeDataThreeMarketsCurrentRound[2].typeId],
+				[tradeDataThreeMarketsCurrentRound[2].playerId],
+				[[0]]
+			);
+
+			expect(await userTicket.isTicketExercisable()).to.be.equal(true);
+
+			expect(await userTicket.isUserTheWinner()).to.be.equal(true);
+
+			systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal('7407407407407407406');
+
+			const userBalanceBefore = await collateral.balanceOf(firstTrader);
+			const defaultLiquidityProviderAddressBefore = await collateral.balanceOf(
+				defaultLiquidityProviderAddress
+			);
+
+			await sportsAMMV2.connect(firstTrader).exerciseTicket(ticketAddress);
+			const userBalanceAfter = await collateral.balanceOf(firstTrader);
+
+			const defaultLiquidityProviderAddressAfter = await collateral.balanceOf(
+				defaultLiquidityProviderAddress
+			);
+
+			expect(userBalanceBefore).to.be.equal(ethers.parseEther('9990'));
+			expect(userBalanceAfter).to.be.equal(ethers.parseEther('9997.407407407407407406'));
+
+			expect(defaultLiquidityProviderAddressBefore).to.be.equal(
+				ethers.parseEther('9982.449572649572649577')
+			);
+			expect(defaultLiquidityProviderAddressAfter).to.be.equal(
+				ethers.parseEther('10002.392592592592592594')
+			);
+
+			const ticketBalanceAfter = await collateral.balanceOf(ticketAddress);
+			expect(ticketBalanceAfter).to.be.equal(0);
+		});
+	});
+});

--- a/test/contracts/Overtime/SportsAMMV2SystemBets/systemBetsPayoutCombos.js
+++ b/test/contracts/Overtime/SportsAMMV2SystemBets/systemBetsPayoutCombos.js
@@ -1,0 +1,379 @@
+const { loadFixture } = require('@nomicfoundation/hardhat-toolbox/network-helpers');
+const { expect } = require('chai');
+const {
+	deployAccountsFixture,
+	deploySportsAMMV2Fixture,
+} = require('../../../utils/fixtures/overtimeFixtures');
+const {
+	BUY_IN_AMOUNT,
+	ADDITIONAL_SLIPPAGE,
+	RESULT_TYPE,
+	TYPE_ID_TOTAL,
+	TYPE_ID_SPREAD,
+	TYPE_ID_WINNER_TOTAL,
+} = require('../../../constants/overtime');
+const { ZERO_ADDRESS } = require('../../../constants/general');
+
+describe('SportsAMMV2 system bets', () => {
+	let sportsAMMV2,
+		sportsAMMV2RiskManager,
+		sportsAMMV2LiquidityPool,
+		tradeDataCurrentRound,
+		tradeDataTenMarketsCurrentRound,
+		tradeDataThreeMarketsCurrentRound,
+		firstLiquidityProvider,
+		firstTrader,
+		collateral,
+		sportsAMMV2Manager,
+		sportsAMMV2ResultManager,
+		userTicket,
+		ticketAddress;
+
+	beforeEach(async () => {
+		({
+			sportsAMMV2,
+			sportsAMMV2RiskManager,
+			sportsAMMV2Manager,
+			sportsAMMV2LiquidityPool,
+			tradeDataCurrentRound,
+			tradeDataTenMarketsCurrentRound,
+			tradeDataThreeMarketsCurrentRound,
+			collateral,
+			sportsAMMV2ResultManager,
+		} = await loadFixture(deploySportsAMMV2Fixture));
+		({ firstLiquidityProvider, firstTrader } = await loadFixture(deployAccountsFixture));
+
+		await sportsAMMV2LiquidityPool
+			.connect(firstLiquidityProvider)
+			.deposit(ethers.parseEther('1000'));
+		await sportsAMMV2LiquidityPool.start();
+
+		const maxSystemBetPayoutAndQuote = await sportsAMMV2RiskManager.getMaxSystemBetPayout(
+			tradeDataThreeMarketsCurrentRound,
+			2,
+			BUY_IN_AMOUNT
+		);
+
+		// console.log('odds0: ' + tradeDataThreeMarketsCurrentRound[0].odds[0] / 1e18); // 0.52 or 1.923 decimal
+		// console.log('odds1: ' + tradeDataThreeMarketsCurrentRound[1].odds[0] / 1e18); // 0.5 or 2 decimal
+		// console.log('odds2: ' + tradeDataThreeMarketsCurrentRound[2].odds[0] / 1e18); // 0.9 or 1.111 decimal
+
+		expect(maxSystemBetPayoutAndQuote.systemBetPayout).to.equal('27350427350427350423');
+
+		await sportsAMMV2
+			.connect(firstTrader)
+			.tradeSystemBet(
+				tradeDataThreeMarketsCurrentRound,
+				BUY_IN_AMOUNT,
+				maxSystemBetPayoutAndQuote.systemBetQuote,
+				ADDITIONAL_SLIPPAGE,
+				ZERO_ADDRESS,
+				ZERO_ADDRESS,
+				false,
+				2
+			);
+
+		const activeTickets = await sportsAMMV2Manager.getActiveTickets(0, 100);
+		ticketAddress = activeTickets[0];
+
+		const TicketContract = await ethers.getContractFactory('Ticket');
+		userTicket = await TicketContract.attach(ticketAddress);
+		expect(await userTicket.isSystem()).to.be.equal(true);
+
+		await sportsAMMV2ResultManager.setResultTypesPerMarketTypes(
+			[0, TYPE_ID_TOTAL, TYPE_ID_SPREAD, 11029],
+			[RESULT_TYPE.ExactPosition, RESULT_TYPE.OverUnder, RESULT_TYPE.Spread, RESULT_TYPE.OverUnder]
+		);
+	});
+
+	describe('Trade system bet and check payouts for all combinations', () => {
+		it('Should buy a system ticket (2/3 markets), first two markets won', async () => {
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[0].gameId],
+				[tradeDataThreeMarketsCurrentRound[0].typeId],
+				[tradeDataThreeMarketsCurrentRound[0].playerId],
+				[[5000]]
+			);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[1].gameId],
+				[tradeDataThreeMarketsCurrentRound[1].typeId],
+				[tradeDataThreeMarketsCurrentRound[1].playerId],
+				[[0]]
+			);
+
+			let systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal(0);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[2].gameId],
+				[tradeDataThreeMarketsCurrentRound[2].typeId],
+				[tradeDataThreeMarketsCurrentRound[2].playerId],
+				[[0]]
+			);
+
+			expect(await userTicket.isTicketExercisable()).to.be.equal(true);
+
+			expect(await userTicket.isUserTheWinner()).to.be.equal(true);
+
+			systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal('27350427350427350423');
+
+			const userBalanceBefore = await collateral.balanceOf(firstTrader);
+
+			await sportsAMMV2.connect(firstTrader).exerciseTicket(ticketAddress);
+			const userBalanceAfter = await collateral.balanceOf(firstTrader);
+
+			expect(userBalanceBefore).to.be.equal(ethers.parseEther('9990'));
+			expect(userBalanceAfter).to.be.equal(ethers.parseEther('10017.350427350427350423'));
+
+			const ticketBalanceAfter = await collateral.balanceOf(ticketAddress);
+			expect(ticketBalanceAfter).to.be.equal(0);
+		});
+		it('Should buy a system ticket (2/3 markets), first two markets won', async () => {
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[0].gameId],
+				[tradeDataThreeMarketsCurrentRound[0].typeId],
+				[tradeDataThreeMarketsCurrentRound[0].playerId],
+				[[5000]]
+			);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[1].gameId],
+				[tradeDataThreeMarketsCurrentRound[1].typeId],
+				[tradeDataThreeMarketsCurrentRound[1].playerId],
+				[[0]]
+			);
+
+			let systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal(0);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[2].gameId],
+				[tradeDataThreeMarketsCurrentRound[2].typeId],
+				[tradeDataThreeMarketsCurrentRound[2].playerId],
+				[[1]]
+			);
+
+			expect(await userTicket.isTicketExercisable()).to.be.equal(true);
+
+			expect(await userTicket.isUserTheWinner()).to.be.equal(true);
+
+			systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal('12820512820512820511');
+
+			const userBalanceBefore = await collateral.balanceOf(firstTrader);
+			await sportsAMMV2.connect(firstTrader).exerciseTicket(ticketAddress);
+			const userBalanceAfter = await collateral.balanceOf(firstTrader);
+
+			expect(userBalanceBefore).to.be.equal(ethers.parseEther('9990'));
+			expect(userBalanceAfter).to.be.equal(ethers.parseEther('10002.820512820512820511'));
+
+			const ticketBalanceAfter = await collateral.balanceOf(ticketAddress);
+			expect(ticketBalanceAfter).to.be.equal(0);
+		});
+		it('Should buy a system ticket (2/3 markets), first and third markets won', async () => {
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[0].gameId],
+				[tradeDataThreeMarketsCurrentRound[0].typeId],
+				[tradeDataThreeMarketsCurrentRound[0].playerId],
+				[[5000]]
+			);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[1].gameId],
+				[tradeDataThreeMarketsCurrentRound[1].typeId],
+				[tradeDataThreeMarketsCurrentRound[1].playerId],
+				[[1]]
+			);
+
+			let systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal(0);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[2].gameId],
+				[tradeDataThreeMarketsCurrentRound[2].typeId],
+				[tradeDataThreeMarketsCurrentRound[2].playerId],
+				[[0]]
+			);
+
+			expect(await userTicket.isTicketExercisable()).to.be.equal(true);
+
+			expect(await userTicket.isUserTheWinner()).to.be.equal(true);
+
+			systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal('7122507122507122506');
+
+			const userBalanceBefore = await collateral.balanceOf(firstTrader);
+			await sportsAMMV2.connect(firstTrader).exerciseTicket(ticketAddress);
+			const userBalanceAfter = await collateral.balanceOf(firstTrader);
+
+			expect(userBalanceBefore).to.be.equal(ethers.parseEther('9990'));
+			expect(userBalanceAfter).to.be.equal(ethers.parseEther('9997.122507122507122506'));
+
+			const ticketBalanceAfter = await collateral.balanceOf(ticketAddress);
+			expect(ticketBalanceAfter).to.be.equal(0);
+		});
+		it('Should buy a system ticket (2/3 markets), two won, one cancelled', async () => {
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[0].gameId],
+				[tradeDataThreeMarketsCurrentRound[0].typeId],
+				[tradeDataThreeMarketsCurrentRound[0].playerId],
+				[[5000]]
+			);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[1].gameId],
+				[tradeDataThreeMarketsCurrentRound[1].typeId],
+				[tradeDataThreeMarketsCurrentRound[1].playerId],
+				[[0]]
+			);
+
+			let systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal(0);
+
+			await sportsAMMV2ResultManager.cancelMarkets(
+				[tradeDataThreeMarketsCurrentRound[2].gameId],
+				[tradeDataThreeMarketsCurrentRound[2].typeId],
+				[tradeDataThreeMarketsCurrentRound[2].playerId],
+				[0]
+			);
+
+			expect(await userTicket.isTicketExercisable()).to.be.equal(true);
+
+			expect(await userTicket.isUserTheWinner()).to.be.equal(true);
+
+			systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal('25897435897435897432');
+
+			const userBalanceBefore = await collateral.balanceOf(firstTrader);
+			await sportsAMMV2.connect(firstTrader).exerciseTicket(ticketAddress);
+			const userBalanceAfter = await collateral.balanceOf(firstTrader);
+
+			expect(userBalanceBefore).to.be.equal(ethers.parseEther('9990'));
+			expect(userBalanceAfter).to.be.equal(ethers.parseEther('10015.897435897435897432'));
+
+			const ticketBalanceAfter = await collateral.balanceOf(ticketAddress);
+			expect(ticketBalanceAfter).to.be.equal(0);
+		});
+		it('Should buy a system ticket (2/3 markets), 1 won, two cancelled', async () => {
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[0].gameId],
+				[tradeDataThreeMarketsCurrentRound[0].typeId],
+				[tradeDataThreeMarketsCurrentRound[0].playerId],
+				[[5000]]
+			);
+
+			await sportsAMMV2ResultManager.cancelMarkets(
+				[tradeDataThreeMarketsCurrentRound[1].gameId],
+				[tradeDataThreeMarketsCurrentRound[1].typeId],
+				[tradeDataThreeMarketsCurrentRound[1].playerId],
+				[0]
+			);
+
+			let systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal(0);
+
+			await sportsAMMV2ResultManager.cancelMarkets(
+				[tradeDataThreeMarketsCurrentRound[2].gameId],
+				[tradeDataThreeMarketsCurrentRound[2].typeId],
+				[tradeDataThreeMarketsCurrentRound[2].playerId],
+				[0]
+			);
+
+			expect(await userTicket.isTicketExercisable()).to.be.equal(true);
+
+			expect(await userTicket.isUserTheWinner()).to.be.equal(true);
+
+			systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal('16153846153846153843');
+
+			const userBalanceBefore = await collateral.balanceOf(firstTrader);
+			await sportsAMMV2.connect(firstTrader).exerciseTicket(ticketAddress);
+			const userBalanceAfter = await collateral.balanceOf(firstTrader);
+
+			expect(userBalanceBefore).to.be.equal(ethers.parseEther('9990'));
+			expect(userBalanceAfter).to.be.equal(ethers.parseEther('10006.153846153846153843'));
+
+			const ticketBalanceAfter = await collateral.balanceOf(ticketAddress);
+			expect(ticketBalanceAfter).to.be.equal(0);
+		});
+		it('Should buy a system ticket (2/3 markets), 2 lost, 1 cancelled', async () => {
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[0].gameId],
+				[tradeDataThreeMarketsCurrentRound[0].typeId],
+				[tradeDataThreeMarketsCurrentRound[0].playerId],
+				[[0]]
+			);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[1].gameId],
+				[tradeDataThreeMarketsCurrentRound[1].typeId],
+				[tradeDataThreeMarketsCurrentRound[1].playerId],
+				[[1]]
+			);
+
+			let systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal(0);
+
+			await sportsAMMV2ResultManager.cancelMarkets(
+				[tradeDataThreeMarketsCurrentRound[2].gameId],
+				[tradeDataThreeMarketsCurrentRound[2].typeId],
+				[tradeDataThreeMarketsCurrentRound[2].playerId],
+				[0]
+			);
+
+			expect(await userTicket.isTicketExercisable()).to.be.equal(true);
+
+			expect(await userTicket.isUserTheWinner()).to.be.equal(false);
+
+			systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal(0);
+
+			const userBalanceBefore = await collateral.balanceOf(firstTrader);
+			await sportsAMMV2.connect(firstTrader).exerciseTicket(ticketAddress);
+			const userBalanceAfter = await collateral.balanceOf(firstTrader);
+
+			expect(userBalanceBefore).to.be.equal(ethers.parseEther('9990'));
+			expect(userBalanceAfter).to.be.equal(ethers.parseEther('9990'));
+
+			const ticketBalanceAfter = await collateral.balanceOf(ticketAddress);
+			expect(ticketBalanceAfter).to.be.equal(0);
+		});
+		it('Should buy a system ticket (2/3 markets), 2 lost, 1 unresolved, but user already lost', async () => {
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[0].gameId],
+				[tradeDataThreeMarketsCurrentRound[0].typeId],
+				[tradeDataThreeMarketsCurrentRound[0].playerId],
+				[[0]]
+			);
+
+			await sportsAMMV2ResultManager.setResultsPerMarkets(
+				[tradeDataThreeMarketsCurrentRound[1].gameId],
+				[tradeDataThreeMarketsCurrentRound[1].typeId],
+				[tradeDataThreeMarketsCurrentRound[1].playerId],
+				[[1]]
+			);
+
+			expect(await userTicket.isTicketExercisable()).to.be.equal(true);
+
+			let systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal(0);
+
+			expect(await userTicket.isUserTheWinner()).to.be.equal(false);
+
+			systemBetPayout = await userTicket.getSystemBetPayout();
+			expect(systemBetPayout).to.be.equal(0);
+
+			const userBalanceBefore = await collateral.balanceOf(firstTrader);
+			await sportsAMMV2.connect(firstTrader).exerciseTicket(ticketAddress);
+			const userBalanceAfter = await collateral.balanceOf(firstTrader);
+
+			expect(userBalanceBefore).to.be.equal(ethers.parseEther('9990'));
+			expect(userBalanceAfter).to.be.equal(ethers.parseEther('9990'));
+
+			const ticketBalanceAfter = await collateral.balanceOf(ticketAddress);
+			expect(ticketBalanceAfter).to.be.equal(0);
+		});
+	});
+});

--- a/test/contracts/Overtime/Ticket/ExerciseAndExpireMarkets.js
+++ b/test/contracts/Overtime/Ticket/ExerciseAndExpireMarkets.js
@@ -113,9 +113,6 @@ describe('Ticket Exercise and Expire', () => {
 					false
 				);
 
-			let volumeFirstTrader = await stakingThales.volume(firstTrader);
-			expect(volumeFirstTrader).to.be.equal(BUY_IN_AMOUNT);
-
 			const activeTickets = await sportsAMMV2Manager.getActiveTickets(0, 100);
 			const ticketAddress = activeTickets[0];
 

--- a/test/utils/fixtures/overtimeFixtures.js
+++ b/test/utils/fixtures/overtimeFixtures.js
@@ -456,6 +456,7 @@ async function deploySportsAMMV2Fixture() {
 		tradeDataNextRound,
 		tradeDataCrossRounds,
 		tradeDataTenMarketsCurrentRound,
+		tradeDataThreeMarketsCurrentRound,
 		tradeDataSameGames,
 		sameGameWithFirstPlayerProps,
 		sameGameWithSecondPlayerProps,
@@ -472,6 +473,7 @@ async function deploySportsAMMV2Fixture() {
 		...tradeDataNextRound,
 		...tradeDataCrossRounds,
 		...tradeDataTenMarketsCurrentRound,
+		...tradeDataThreeMarketsCurrentRound,
 	];
 
 	for (let index = 0; index < allTradeData.length; index++) {
@@ -787,6 +789,7 @@ async function deploySportsAMMV2Fixture() {
 		tradeDataNextRound,
 		tradeDataCrossRounds,
 		tradeDataTenMarketsCurrentRound,
+		tradeDataThreeMarketsCurrentRound,
 		liveTradingProcessor,
 		mockChainlinkOracle,
 		sportsAMMV2Data,

--- a/test/utils/overtime.js
+++ b/test/utils/overtime.js
@@ -47,6 +47,11 @@ const getTicketTradeData = () => {
 	tradeDataTenMarketsCurrentRound.push(getTradeDataItem(marketsTree[10], 0));
 	tradeDataTenMarketsCurrentRound.push(getTradeDataItem(marketsTree[11], 0));
 
+	const tradeDataThreeMarketsCurrentRound = [];
+	tradeDataThreeMarketsCurrentRound.push(getTradeDataItem(marketsTree[0].childMarkets[3], 0));
+	tradeDataThreeMarketsCurrentRound.push(getTradeDataItem(marketsTree[1], 0));
+	tradeDataThreeMarketsCurrentRound.push(getTradeDataItem(marketsTree[2], 0));
+
 	const tradeDataSameGames = [];
 	tradeDataSameGames.push(getTradeDataItem(marketsTree[0], 0));
 	tradeDataSameGames.push(getTradeDataItem(marketsTree[0], 0));
@@ -75,6 +80,7 @@ const getTicketTradeData = () => {
 		tradeDataNextRound,
 		tradeDataCrossRounds,
 		tradeDataTenMarketsCurrentRound,
+		tradeDataThreeMarketsCurrentRound,
 		tradeDataSameGames,
 		sameGameWithFirstPlayerProps,
 		sameGameWithSecondPlayerProps,


### PR DESCRIPTION
Added system bets.
All combinations are generated upon ticket creation.
Add methods to calculate max payout for a combination, as well as exact payout on exercise.
Unit test coverage is pretty good so far, pending is to test THALES extra payout.
Risk management works the same as before, treating a system bet as a normal parlay.