### PR TITLE
Fix: Use buy-in amount for accurate risk rebalance on non-betting positions

### DIFF
--- a/contracts/core/AMM/SportsAMMV2RiskManager.sol
+++ b/contracts/core/AMM/SportsAMMV2RiskManager.sol
@@ -408,7 +408,6 @@ contract SportsAMMV2RiskManager is Initializable, ProxyOwned, ProxyPausable, Pro
         bool _isSGP
     ) external onlySportsAMM(msg.sender) {
         uint numOfMarkets = _tradeData.length;
-        bool isSystemBet = _systemBetDenominator > 1;
         for (uint i; i < numOfMarkets; ++i) {
             ISportsAMMV2.TradeData memory marketTradeData = _tradeData[i];
 
@@ -423,8 +422,10 @@ contract SportsAMMV2RiskManager is Initializable, ProxyOwned, ProxyPausable, Pro
             uint amountToBuy = odds[position] == 0 ? 0 : (ONE * _buyInAmount) / odds[position];
             if (amountToBuy > _buyInAmount) {
                 uint marketRiskAmount = amountToBuy - _buyInAmount;
-                if (isSystemBet) {
+                // for system bet
+                if (_systemBetDenominator > 1) {
                     marketRiskAmount = (marketRiskAmount * ONE * _systemBetDenominator) / (numOfMarkets * ONE);
+                    _buyInAmount = (_buyInAmount * ONE * _systemBetDenominator) / (numOfMarkets * ONE);
                 }
 
                 require(
@@ -433,7 +434,7 @@ contract SportsAMMV2RiskManager is Initializable, ProxyOwned, ProxyPausable, Pro
                 );
                 require(!_isRiskPerGameExceeded(marketTradeData, marketRiskAmount), "ExceededGameRisk");
                 require(_isSGP || !_isInvalidCombinationOnTicket(_tradeData, marketTradeData, i), "InvalidCombination");
-                _updateRisk(marketTradeData, marketRiskAmount);
+                _updateRisk(marketTradeData, marketRiskAmount, _buyInAmount);
             }
         }
         if (_isSGP) {
@@ -604,18 +605,23 @@ contract SportsAMMV2RiskManager is Initializable, ProxyOwned, ProxyPausable, Pro
         }
     }
 
-    function _updateRisk(ISportsAMMV2.TradeData memory _marketTradeData, uint marketRiskAmount) internal {
+    function _updateRisk(ISportsAMMV2.TradeData memory _marketTradeData, uint marketRiskAmount, uint _buyInAmount) internal {
         bytes32 gameId = _marketTradeData.gameId;
         uint16 typeId = _marketTradeData.typeId;
         uint24 playerId = _marketTradeData.playerId;
         uint8 position = _marketTradeData.position;
 
         for (uint j = 0; j < _marketTradeData.odds.length; j++) {
-            int currentRiskPerMarketTypeAndPosition = riskPerMarketTypeAndPosition[gameId][typeId][playerId][j];
-            riskPerMarketTypeAndPosition[gameId][typeId][playerId][j] = (j == position)
-                ? currentRiskPerMarketTypeAndPosition + int(marketRiskAmount)
-                : currentRiskPerMarketTypeAndPosition - int(marketRiskAmount);
+            int currentRisk = riskPerMarketTypeAndPosition[gameId][typeId][playerId][j];
+            if (j == position) {
+                // Add risk for selected position
+                riskPerMarketTypeAndPosition[gameId][typeId][playerId][j] = currentRisk + int(marketRiskAmount);
+            } else {
+                // Reduce risk for unselected positions by buy-in amount
+                riskPerMarketTypeAndPosition[gameId][typeId][playerId][j] = currentRisk - int(_buyInAmount);
+            }
         }
+
         spentOnGame[gameId] += marketRiskAmount;
     }
 

--- a/test/contracts/Overtime/SportsAMMV2/QuotesAndTradesAmountsToBuy.js
+++ b/test/contracts/Overtime/SportsAMMV2/QuotesAndTradesAmountsToBuy.js
@@ -122,8 +122,8 @@ describe('SportsAMMV2 Quotes And Trades', () => {
 			);
 
 			expect(positionRisk0).to.equal('6153846153846153846');
-			expect(positionRisk1).to.equal('6666666666666666666');
-			expect(positionRisk2).to.equal('740740740740740740');
+			expect(positionRisk1).to.equal('4444444444444444444');
+			expect(positionRisk2).to.equal('329218106995884773');
 		});
 	});
 });

--- a/test/contracts/Overtime/SportsAMMV2RiskManager/CheckAndUpdateRisks.js
+++ b/test/contracts/Overtime/SportsAMMV2RiskManager/CheckAndUpdateRisks.js
@@ -78,7 +78,7 @@ describe('SportsAMMV2RiskManager Check And Update Risks', () => {
 			let spentOnGame = await sportsAMMV2RiskManager.spentOnGame(tradeDataCurrentRound[0].gameId);
 
 			expect(Number(ethers.formatEther(positionRisk0))).to.equal(marketRisk0);
-			expect(Number(ethers.formatEther(positionRisk1))).to.equal(-marketRisk0);
+			expect(Number(ethers.formatEther(positionRisk1))).to.equal(-formattedBuyInAmount);
 			expect(Number(ethers.formatEther(spentOnGame))).to.equal(marketRisk0);
 
 			const newBuyInAmount = ethers.parseEther('5');
@@ -119,15 +119,18 @@ describe('SportsAMMV2RiskManager Check And Update Risks', () => {
 			);
 			spentOnGame = await sportsAMMV2RiskManager.spentOnGame(tradeDataCurrentRound[0].gameId);
 
+			// Final expected values considering new logic
+			const expectedPositionRisk0 = marketRisk0 - formattedNewBuyInAmount;
+			const expectedPositionRisk1 = -formattedBuyInAmount + marketRisk1;
+			const expectedSpent = marketRisk0 + marketRisk1;
+
 			expect(Number(ethers.formatEther(positionRisk0)).toFixed(4)).to.equal(
-				(marketRisk0 - marketRisk1).toFixed(4)
+				expectedPositionRisk0.toFixed(4)
 			);
 			expect(Number(ethers.formatEther(positionRisk1)).toFixed(4)).to.equal(
-				(-marketRisk0 + marketRisk1).toFixed(4)
+				expectedPositionRisk1.toFixed(4)
 			);
-			expect(Number(ethers.formatEther(spentOnGame)).toFixed(4)).to.equal(
-				(marketRisk0 + marketRisk1).toFixed(4)
-			);
+			expect(Number(ethers.formatEther(spentOnGame)).toFixed(4)).to.equal(expectedSpent.toFixed(4));
 		});
 	});
 

--- a/test/contracts/Overtime/SportsAMMV2RiskManager/CheckAndUpdateRisksSystemBets.js
+++ b/test/contracts/Overtime/SportsAMMV2RiskManager/CheckAndUpdateRisksSystemBets.js
@@ -1,0 +1,107 @@
+const { loadFixture, time } = require('@nomicfoundation/hardhat-toolbox/network-helpers');
+const { expect } = require('chai');
+const {
+	deploySportsAMMV2Fixture,
+	deployAccountsFixture,
+} = require('../../../utils/fixtures/overtimeFixtures');
+const { BUY_IN_AMOUNT, ADDITIONAL_SLIPPAGE, SPORT_ID_NBA } = require('../../../constants/overtime');
+const { ZERO_ADDRESS, ONE_WEEK_IN_SECS } = require('../../../constants/general');
+
+describe('SportsAMMV2RiskManager Check And Update Risks', () => {
+	let sportsAMMV2RiskManager,
+		sportsAMMV2,
+		sportsAMMV2LiquidityPool,
+		tradeDataCurrentRound,
+		tradeDataTenMarketsCurrentRound,
+		sameGameDifferentPlayersDifferentProps,
+		firstTrader,
+		firstLiquidityProvider,
+		tradeDataNotActive;
+
+	beforeEach(async () => {
+		({
+			sportsAMMV2RiskManager,
+			sportsAMMV2,
+			sportsAMMV2LiquidityPool,
+			tradeDataCurrentRound,
+			tradeDataTenMarketsCurrentRound,
+			sameGameDifferentPlayersDifferentProps,
+			tradeDataNotActive,
+		} = await loadFixture(deploySportsAMMV2Fixture));
+		({ firstTrader, firstLiquidityProvider } = await loadFixture(deployAccountsFixture));
+
+		await sportsAMMV2LiquidityPool
+			.connect(firstLiquidityProvider)
+			.deposit(ethers.parseEther('5000'));
+		await sportsAMMV2LiquidityPool.start();
+		await sportsAMMV2LiquidityPool.setUtilizationRate(ethers.parseEther('1'));
+	});
+	describe('System bet risk updates', () => {
+		it('Should correctly update risks and spentOnGame for first market in a system bet (3 from 10)', async () => {
+			const systemBetDenominator = 3;
+			const tradeData = tradeDataTenMarketsCurrentRound;
+			const numMarkets = tradeData.length;
+
+			for (let i = 0; i < numMarkets; i++) {
+				tradeData[i].position = 0;
+			}
+
+			const quote = await sportsAMMV2.tradeQuoteSystem(
+				tradeData,
+				BUY_IN_AMOUNT,
+				ZERO_ADDRESS,
+				false,
+				systemBetDenominator
+			);
+
+			await sportsAMMV2
+				.connect(firstTrader)
+				.tradeSystemBet(
+					tradeData,
+					BUY_IN_AMOUNT,
+					quote.totalQuote,
+					ADDITIONAL_SLIPPAGE,
+					ZERO_ADDRESS,
+					ZERO_ADDRESS,
+					false,
+					systemBetDenominator
+				);
+
+			const formattedBuyIn = Number(ethers.formatEther(BUY_IN_AMOUNT));
+			const market = tradeData[0];
+			const odds = Number(ethers.formatEther(market.odds[market.position]));
+
+			const rawMarketRisk = formattedBuyIn / odds - formattedBuyIn;
+			const scaledMarketRiskAmount = (rawMarketRisk * systemBetDenominator) / numMarkets;
+			const scaledBuyInForRisk = (formattedBuyIn * systemBetDenominator) / numMarkets;
+
+			const riskSelected = await sportsAMMV2RiskManager.riskPerMarketTypeAndPosition(
+				market.gameId,
+				market.typeId,
+				market.playerId,
+				market.position
+			);
+
+			const riskUnselected = await sportsAMMV2RiskManager.riskPerMarketTypeAndPosition(
+				market.gameId,
+				market.typeId,
+				market.playerId,
+				market.position === 0 ? 1 : 0 // flip position
+			);
+
+			const spentOnGame = await sportsAMMV2RiskManager.spentOnGame(market.gameId);
+
+			expect(Number(ethers.formatEther(riskSelected)).toFixed(4)).to.equal(
+				scaledMarketRiskAmount.toFixed(4)
+			);
+
+			expect(Number(ethers.formatEther(riskUnselected)).toFixed(4)).to.equal(
+				Number(-scaledBuyInForRisk).toFixed(4)
+			);
+
+			expect(Number(ethers.formatEther(spentOnGame)).toFixed(4)).to.equal(
+				scaledMarketRiskAmount.toFixed(4)
+			);
+		});
+	});
+});


### PR DESCRIPTION
🔧 Description
This PR refactors the risk update logic in SportsAMMV2RiskManager to ensure accurate rebalancing of position-level exposure when a market is traded. Previously, risk was only added to the selected position, but unselected sides were not properly rebalanced using the actual buy-in value.

✅ Key Changes
Introduced _buyInAmount as an explicit argument to _updateRisk().

Updated the loop in _updateRisk() to:

Add marketRiskAmount to the selected position.

Subtract buyInAmount from all non-selected positions, improving accuracy and symmetry of risk tracking.

This adjustment affects all bet types, including standard, system, and SGP trades.

🎯 Why It Matters
This change ensures:

Accurate exposure tracking per market position.

Proper risk offsetting for unused outcomes.

Cleaner settlement and less skewed risk accumulation, especially under high-frequency trading.

🧪 Tests
Existing quote and trade tests were updated to reflect the rebalanced risk expectations.